### PR TITLE
fix authz flow

### DIFF
--- a/contracts/pyxis-sm-base/src/contract.rs
+++ b/contracts/pyxis-sm-base/src/contract.rs
@@ -132,9 +132,9 @@ pub fn pre_execute(
             // UnregisterPlugin, RegisterPlugin or UpdatePlugin
             // only smart-account owner can execute those msgs
             // error will be thrown at `after_execute` handler
-            if is_authz {
-                return Ok(Response::new().add_attribute("action", "pre_execute"));
-            }
+            // if is_authz {
+            //    return Err(ContractError::Std(StdError::generic_err("Unauthorization")));
+            // }
 
             let msg_raw: Result<ExecuteMsg, Error> =
                 serde_json_wasm::from_slice(msg_exec.msg.as_slice());


### PR DESCRIPTION
- execute normal `pre_execute` flow for authz case
not allow smart account ExecutionMessages are executed throws _authz_, but the error should only be handled in `after_execute`. Omitting plugin calls in `pre_execute` may result in missing error warnings